### PR TITLE
Geocoding

### DIFF
--- a/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/Extractor.java
+++ b/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/Extractor.java
@@ -127,24 +127,16 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 					+ "FILTER NOT EXISTS {?address s:geo ?geo}"
 				+  "}";*/ 
 		String sOrgConstructQuery = "PREFIX s: <http://schema.org/> "
-				+ "CONSTRUCT {?address ?p ?o}"
+				+ "CONSTRUCT {?address ?p ?o ; s:addressCountry ?country }"
 				+ "WHERE "
 				+ "{"
 					+ "?address a s:PostalAddress ;"
 					+ "			?p ?o . "
-//					+ "FILTER NOT EXISTS {?address s:geo ?geo}"
-				+  "}"; 
-		/*String sOrgQuery = "PREFIX s: <http://schema.org/> "
-				+ "SELECT DISTINCT * "
-				+ "WHERE "
-				+ "{"
-					+ "{?address a s:PostalAddress . } "
-					+ "UNION { ?address s:streetAddress ?street . } "
-					+ "UNION { ?address s:addressRegion ?region . } "
-					+ "UNION { ?address s:addressLocality ?locality . } "
-					+ "UNION { ?address s:postalCode ?postal . } "
-					+ "UNION { ?address s:addressCountry ?country . } "
-				+ " }";*/
+                + " OPTIONAL {"
+                    + "?address s:addressCountry ?c ."
+                    + "?c s:name ?country ."
+                + "}"
+				+  "}";
 
 		LOG.debug("Geocoder init");
 		
@@ -195,11 +187,9 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 					if (it1.hasNext())
 					{
 						Value currentValue = it1.next().getObject();
-						if (currentValue != null)
+						if (currentValue != null && !currentValue.stringValue().startsWith("http://"))
 						{
-							//logger.trace("Currently " + currentBinding);
 							String currentValueString = currentValue.stringValue();
-							//logger.trace("Value " + currentValueString);
 							addressToGeoCode.append(currentValueString);
 							addressToGeoCode.append(" ");
 						}

--- a/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/Extractor.java
+++ b/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/Extractor.java
@@ -265,8 +265,9 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 				String cachedFile = null;
 				try {
 					cachedFile = FileUtils.readFileToString(hFile);
+                    continue;
 				} catch (IOException e) {
-					LOG.error(e.getLocalizedMessage());
+					LOG.error("Failed to load cached result for " + address + " with error " + e.getLocalizedMessage());
 				}
 				
 				int indexOfLocation = cachedFile.indexOf("location=LatLng") + 16;

--- a/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/Extractor.java
+++ b/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/Extractor.java
@@ -1,32 +1,10 @@
 package cz.opendata.linked.geocoder.google;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.math.BigDecimal;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Iterator;
-
-import org.openrdf.model.Graph;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.vocabulary.RDF;
-import org.openrdf.query.QueryEvaluationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.code.geocoder.Geocoder;
 import com.google.code.geocoder.GeocoderRequestBuilder;
 import com.google.code.geocoder.model.GeocodeResponse;
 import com.google.code.geocoder.model.GeocoderRequest;
 import com.google.code.geocoder.model.GeocoderStatus;
-
 import cz.cuni.mff.xrg.odcs.commons.dpu.DPU;
 import cz.cuni.mff.xrg.odcs.commons.dpu.DPUContext;
 import cz.cuni.mff.xrg.odcs.commons.dpu.DPUException;
@@ -40,8 +18,19 @@ import cz.cuni.mff.xrg.odcs.commons.web.ConfigDialogProvider;
 import cz.cuni.mff.xrg.odcs.rdf.exceptions.InvalidQueryException;
 import cz.cuni.mff.xrg.odcs.rdf.help.MyTupleQueryResultIf;
 import cz.cuni.mff.xrg.odcs.rdf.interfaces.RDFDataUnit;
+import org.apache.commons.io.FileUtils;
+import org.openrdf.model.*;
+import org.openrdf.model.vocabulary.RDF;
+import org.openrdf.query.QueryEvaluationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.apache.commons.io.*;
+import java.io.*;
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Iterator;
 
 @AsExtractor
 public class Extractor 
@@ -123,6 +112,7 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 		//URI xsdDecimal = outGeo.createURI("http://www.w3.org/2001/XMLSchema#decimal");
 		URI longURI = outGeo.createURI("http://schema.org/longitude");
 		URI latURI = outGeo.createURI("http://schema.org/latitude");
+        URI urlURI = outGeo.createURI("http://schema.org/url");
 		String countQuery = "PREFIX s: <http://schema.org/> "
 				+ "SELECT (COUNT (*) as ?count) "
 				+ "WHERE "
@@ -290,12 +280,14 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 				String uri = currentAddressURI.stringValue();
 				URI addressURI = outGeo.createURI(uri);
 				URI coordURI = outGeo.createURI(uri+"/geocoordinates/google");
+                URI webURI = outGeo.createURI("http://google.com/maps?q=" + latitude.toString() + "," + longitude.toString());
 				
 				outGeo.addTriple(addressURI, geoURI , coordURI);
 				outGeo.addTriple(coordURI, RDF.TYPE, geocoordsURI);
 				outGeo.addTriple(coordURI, longURI, outGeo.createLiteral(longitude.toString()/*, xsdDecimal*/));
 				outGeo.addTriple(coordURI, latURI, outGeo.createLiteral(latitude.toString()/*, xsdDecimal*/));
 				outGeo.addTriple(coordURI, dcsource, googleURI);
+                outGeo.addTriple(coordURI, urlURI, webURI);
 			}
 			if (ctx.canceled()) LOG.info("Cancelled");
 			

--- a/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/ExtractorConfig.java
+++ b/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/ExtractorConfig.java
@@ -9,8 +9,6 @@ import cz.cuni.mff.xrg.odcs.commons.module.config.DPUConfigObjectBase;
  */
 public class ExtractorConfig extends DPUConfigObjectBase {
 	
-	private static final long serialVersionUID = 8719241993054209502L;
-
 	private int limit = 2400;
 	
 	private int interval = 1000;

--- a/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/ExtractorConfig.java
+++ b/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/ExtractorConfig.java
@@ -14,6 +14,8 @@ public class ExtractorConfig extends DPUConfigObjectBase {
 	private int interval = 1000;
 	
     private int hoursToCheck = 24;
+
+    private boolean generateMapUrl = false;
 	
 	@Override
     public boolean isValid() {
@@ -43,5 +45,13 @@ public class ExtractorConfig extends DPUConfigObjectBase {
 	public void setHoursToCheck(int hoursToCheck) {
 		this.hoursToCheck = hoursToCheck;
 	}
+
+    public boolean isGenerateMapUrl() {
+        return generateMapUrl;
+    }
+
+    public void setGenerateMapUrl(boolean generateMapUrl) {
+        this.generateMapUrl = generateMapUrl;
+    }
 
 }

--- a/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/ExtractorDialog.java
+++ b/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/ExtractorDialog.java
@@ -13,8 +13,6 @@ import cz.cuni.mff.xrg.odcs.commons.module.dialog.BaseConfigDialog;
  */
 public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 
-	private static final long serialVersionUID = 7003725620084616056L;
-
 	private GridLayout mainLayout;
     private TextField interval;
     private TextField limit;

--- a/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/ExtractorDialog.java
+++ b/geocoder-google/src/main/java/cz/opendata/linked/geocoder/google/ExtractorDialog.java
@@ -1,5 +1,6 @@
 package cz.opendata.linked.geocoder.google;
 
+import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.TextField;
@@ -14,6 +15,7 @@ import cz.cuni.mff.xrg.odcs.commons.module.dialog.BaseConfigDialog;
 public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 
 	private GridLayout mainLayout;
+    private CheckBox generateMapUrl;
     private TextField interval;
     private TextField limit;
     private TextField hoursToCheck;
@@ -40,6 +42,11 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
         setWidth("100%");
         setHeight("100%");
 
+        generateMapUrl = new CheckBox("Generate schema:url property with direct link to map");
+        generateMapUrl.setDescription("Useful option for debugging results, URL to the service is constructed automatically and can be opened from SPARQL query result");
+        generateMapUrl.setWidth("100%");
+        mainLayout.addComponent(generateMapUrl);
+
         interval = new TextField();
         interval.setCaption("Interval between downloads:");
         mainLayout.addComponent(interval);
@@ -57,6 +64,7 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
      
 	@Override
 	public void setConfiguration(ExtractorConfig conf) throws ConfigException {
+        generateMapUrl.setValue(conf.isGenerateMapUrl());
 		interval.setValue(Integer.toString(conf.getInterval()));
 		hoursToCheck.setValue(Integer.toString(conf.getHoursToCheck()));
 		limit.setValue(Integer.toString(conf.getLimit()));
@@ -66,7 +74,8 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 	@Override
 	public ExtractorConfig getConfiguration() throws ConfigException {
 		ExtractorConfig conf = new ExtractorConfig();
-		conf.setInterval(Integer.parseInt(interval.getValue()));
+        conf.setGenerateMapUrl(generateMapUrl.getValue());
+        conf.setInterval(Integer.parseInt(interval.getValue()));
 		conf.setHoursToCheck(Integer.parseInt(hoursToCheck.getValue()));
 		conf.setLimit(Integer.parseInt(limit.getValue()));
 		return conf;

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Address.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Address.java
@@ -9,6 +9,7 @@ import java.net.URLEncoder;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class Address {
 
@@ -154,10 +155,19 @@ public class Address {
     }
 
     private boolean cityIsSubstringOfStreet() {
-        return street != city && (street.matches("^\\d+\\w?(/\\d+\\w?)? " + city) || street.matches(city + " \\d+"));
+        String cityRegexp = Pattern.quote(city);
+        return street != city && (street.matches("^\\d+\\w?(/\\d+\\w?)? " + cityRegexp) || street.matches(cityRegexp + " \\d+"));
     }
 
     private boolean streetIsOnlyNumeric() {
         return street.trim().matches("^\\d+$");
+    }
+
+    public boolean equals(Address other) {
+        return street.equals(other.street)
+                && city.equals(other.city)
+                && region.equals(other.region)
+                && country.equals(other.country)
+                && postalCode.equals(other.postalCode);
     }
 }

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Address.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Address.java
@@ -1,0 +1,135 @@
+package cz.opendata.linked.geocoder.nominatim;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openrdf.model.*;
+import org.openrdf.model.impl.URIImpl;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Iterator;
+
+public class Address {
+
+    private final ExtractorConfig config;
+    private String street;
+    private String city;
+    private String region;
+    private String country;
+    private String postalCode;
+    
+    private static URI streetAddressURI = new URIImpl("http://schema.org/streetAddress");
+    private static URI addressRegionURI = new URIImpl("http://schema.org/addressRegion");
+    private static URI addressLocalityURI = new URIImpl("http://schema.org/addressLocality");
+    private static URI postalCodeURI = new URIImpl("http://schema.org/postalCode");
+
+    public Address(ExtractorConfig config, String street, String city, String region, String country, String postalCode) {
+        this.config = config;
+
+        if (street == null || !config.isUseStreet()) {
+            street = "";
+        }
+        if (city == null || !config.isUseLocality()) {
+            city = "";
+        } else if (config.isStripNumFromLocality()) {
+            city = stripNumbersFromCity(city);
+        }
+        if (region == null || !config.isUseRegion()) {
+            region = "";
+        }
+        if (country == null) {
+            country = "";
+        }
+        if (postalCode == null || !config.isUsePostalCode()) {
+            postalCode = "";
+        }
+        this.street = street;
+        this.city = city;
+        this.region = region;
+        this.country = country;
+        this.postalCode = postalCode;
+    }
+
+    private String stripNumbersFromCity(String city) {
+        return city.replaceAll("[\\s\\W][\\dIVX]+[\\s\\W]",  " ");
+    }
+
+    public static Address buildFromRdf(ExtractorConfig config, Graph graph, Resource address) {
+
+        String street = getAddressPart(address, streetAddressURI, graph);
+        String city = getAddressPart(address, addressLocalityURI, graph);
+        String region = getAddressPart(address, addressRegionURI, graph);
+        String postalCode = getAddressPart(address, postalCodeURI, graph);
+
+        return new Address(config, street, city, region, config.getCountry(), postalCode);
+    }
+
+    private static String getAddressPart(Resource address, URI currentPropertyURI, Graph graph) {
+        Iterator<Statement> it1 = graph.match(address, currentPropertyURI, null);
+        String currentValueString = null;
+        if (it1.hasNext())
+        {
+            Value currentValue = it1.next().getObject();
+            if (currentValue != null)
+            {
+                currentValueString = currentValue.stringValue();
+            }
+        }
+        return currentValueString;
+    }
+
+    public String toString() {
+        return toString(", ");
+    }
+    public String toString(String separator) {
+        return StringUtils.join(getParts(), separator);
+    }
+
+    public String toFilename() {
+        String filename = toString().replaceAll("\\s", "_").replaceAll("[^\\d\\w_]", "-");
+        return filename;
+    }
+
+    private String[] getParts() {
+        String[] parts = new String[5];
+        if (street != "") {
+            parts[0] = street;
+        }
+        if (city != "") {
+            parts[1] = street;
+        }
+        if (region != "") {
+            parts[2] = region;
+        }
+        if (country != "") {
+            parts[3] = country;
+        }
+        if (postalCode != "") {
+            parts[4] = postalCode;
+        }
+        return parts;
+    }
+
+    public String buildQuery() throws UnsupportedEncodingException {
+        String url = "http://nominatim.openstreetmap.org/search?format=json&";
+        if (config.isStructured()) {
+            url += "&street=" + encodeForUrl(street);
+            url += "&city=" + encodeForUrl(city);
+            url += "&county=" + encodeForUrl(region);
+            url += "&state=" + encodeForUrl(country);
+            url += "&postalcode=" + encodeForUrl(postalCode);
+        }
+        else {
+            url = "&q=" + encodeForUrl(toString(" "));
+        }
+        return url;
+    }
+
+    private String encodeForUrl(String value) throws UnsupportedEncodingException {
+        if (value == null) {
+            return "";
+        } else {
+            return URLEncoder.encode(value, "UTF-8");
+        }
+    }
+
+}

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Address.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Address.java
@@ -86,6 +86,9 @@ public class Address {
 
     public String toFilename() {
         String filename = toString().replaceAll("\\s", "_").replaceAll("[^\\d\\w_]", "-");
+        if (config.isStructured()) {
+            filename = "structured-" + filename;
+        }
         return filename;
     }
 

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
@@ -244,7 +244,7 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 				+ ((config.isUsePostalCode() && postalCode != null) ? postalCode : "")  + " " 
 				+ ((config.isUseRegion() && addressRegion != null) ? addressRegion : "") + " " 
 				+ ((config.isUseStreet() && streetAddress != null) ? streetAddress : "") + " " 
-				+ ((config.isUseLocality() && addressLocality != null) ? (config.isStripNumFromLocality() ? addressLocality.replaceAll("[0-9]",  "").replace(" (I)+", "") : addressLocality) : "");
+				+ ((config.isUseLocality() && addressLocality != null) ? (config.isStripNumFromLocality() ? addressLocality.replaceAll("[\\s\\W][\\dIVX]+[\\s\\W]",  " ") : addressLocality) : "");
 				logger.debug("Address to geocode (" + count + "/" + total + "): " + address);
 								
 				String file;

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
@@ -139,7 +139,7 @@ implements ConfigDialogProvider<ExtractorConfig> {
                 failed++;
                 logger.debug("Failed to geolocate (" + failed + "): " + address);
                 Address alternativeAddress = address.getAlternative();
-                if (alternativeAddress != null) {
+                if (alternativeAddress != null && !alternativeAddress.equals(address)) {
                     logger.debug("Trying alternative address");
                     geocodeAddress(ctx, date, total, lastDownload, currentAddressURI, alternativeAddress);
                 }

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
@@ -47,16 +47,18 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 	 */
 
 	private Logger logger = LoggerFactory.getLogger(DPU.class);
-	private int geocodes = 0;
+	private int geocoded = 0;
 	private int cacheHits = 0;
+    private int count = 0;
+    private int failed = 0;
 	
 	@InputDataUnit(name = "Schema.org addresses")
 	public RDFDataUnit sAddresses;
 
 	@OutputDataUnit(name = "Geocoordinates")
-	public RDFDataUnit outGeo;	
-	
-	public Extractor() {
+	public RDFDataUnit outGeo;
+
+    public Extractor() {
 		super(ExtractorConfig.class);
 	}
 
@@ -64,269 +66,277 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 	public AbstractConfigDialog<ExtractorConfig> getConfigurationDialog() {		
 		return new ExtractorDialog();
 	}
-
-	public class Response {
-	  public Map<String, Geo> descriptor;
-	  //getters&setters
-	  public Response () {  }
-	}
-	
-	public class Geo {
-	  public String lat;
-	  public String lon;
-	  //getters&setters
-	  public Geo () {  }
-	}
-	
-	public class GeoInstanceCreator implements InstanceCreator<Geo> {
-	   public Geo createInstance(Type type) {
-	     return new Geo();
-	   }
-	 }	
-	
-	private int countTodaysCacheFiles(DPUContext ctx)
-	{
-		int count = 0;
-
-		// Directory path here
-		File currentFile;
-		File folder = ctx.getGlobalDirectory();
-		if (!folder.isDirectory()) return 0;
-
-		File[] listOfFiles = folder.listFiles(); 
-		SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
-
-		for (int i = 0; i < listOfFiles.length; i++) 
-		{
-			if (listOfFiles[i].isFile()) 
-			{
-				currentFile = listOfFiles[i];
-
-				Date now = new Date();
-				Date modified = null;
-				try {
-					modified = sdf.parse(sdf.format(currentFile.lastModified()));
-				} catch (ParseException e) {
-					logger.error(e.getLocalizedMessage());
-				}
-				long diff = (now.getTime() - modified.getTime()) / 1000;
-				//System.out.println("Date modified: " + sdf.format(currentFile.lastModified()) + " which is " + diff + " seconds ago.");
-
-				if (diff < (config.getLimitPeriod() * 60 * 60)) count++;
-			}
-		}
-		logger.info("Total of " + count + " positions cached in last " + config.getLimitPeriod() + " hours. " + (config.getLimit() - count) + " remaining.");
-		return count;
-	}
-	
-	private static String getURLContent(String p_sURL) throws IOException
-	{
-	    URL oURL;
-	    String sResponse = null;
-
-        oURL = new URL(p_sURL);
-        try	{
-        	sResponse = IOUtils.toString(oURL, "UTF-8");
-        }
-        catch (Exception e)
-        {
-        	e.printStackTrace();
-        }
-
-	    return sResponse;
-	}
 	
 	public void execute(DPUContext ctx) throws DPUException
 	{
 		java.util.Date date = new java.util.Date();
 		long start = date.getTime();
-	    Gson gson = new GsonBuilder().registerTypeAdapter(Geo.class, new GeoInstanceCreator()).create();
 
-		URI dcsource = outGeo.createURI("http://purl.org/dc/terms/source");
-		URI nominatimURI = outGeo.createURI("http://nominatim.openstreetmap.org");
-		URI geoURI = outGeo.createURI("http://schema.org/geo");
-		URI geocoordsURI = outGeo.createURI("http://schema.org/GeoCoordinates");
-		URI postalAddressURI = sAddresses.createURI("http://schema.org/PostalAddress");
-		//URI xsdDouble = outGeo.createURI("http://www.w3.org/2001/XMLSchema#double");
-		//URI xsdDecimal = outGeo.createURI("http://www.w3.org/2001/XMLSchema#decimal");
-		URI longURI = outGeo.createURI("http://schema.org/longitude");
-		URI latURI = outGeo.createURI("http://schema.org/latitude");
-        URI urlURI = outGeo.createURI("http://schema.org/url");
-		String countQuery = "PREFIX s: <http://schema.org/> "
-				+ "SELECT (COUNT (*) as ?count) "
-				+ "WHERE "
-				+ "{"
-					+ "?address a s:PostalAddress . "
-				+  "}"; 
-		/*String notGCcountQuery = "PREFIX s: <http://schema.org/> "
-				+ "SELECT (COUNT (*) as ?count) "
-				+ "WHERE "
-				+ "{"
-					+ "?address a s:PostalAddress . "
-					+ "FILTER NOT EXISTS {?address s:geo ?geo}"
-				+  "}";*/ 
-		String sOrgConstructQuery = "PREFIX s: <http://schema.org/> "
-				+ "CONSTRUCT {?address ?p ?o}"
-				+ "WHERE "
-				+ "{"
-					+ "?address a s:PostalAddress ;"
-					+ "			?p ?o . "
-//					+ "FILTER NOT EXISTS {?address s:geo ?geo}"
-				+  "}"; 
+        logger.debug("Geocoder init");
 
-		logger.debug("Geocoder init");
-		
-		int total = 0;
-		int ngc = 0;
-		int count = 0;
-		int failed = 0;
-		try {
-			MyTupleQueryResultIf countres = sAddresses.executeSelectQueryAsTuples(countQuery);
-			//MyTupleQueryResult countnotGC = sAddresses.executeSelectQueryAsTuples(notGCcountQuery);
-			total = Integer.parseInt(countres.next().getValue("count").stringValue());
-			//ngc = Integer.parseInt(countnotGC.next().getValue("count").stringValue());
-			ctx.sendMessage(MessageType.INFO, "Found " + total + " addresses");
-		} catch (InvalidQueryException e1) {
-			logger.error(e1.getLocalizedMessage());
-		} catch (NumberFormatException e) {
-			logger.error(e.getLocalizedMessage());
-		} catch (QueryEvaluationException e) {
-			logger.error(e.getLocalizedMessage());
-		}
+        int total = countAddressesInSourceDataUnit();
+        ctx.sendMessage(MessageType.INFO, "Found " + total + " addresses");
 
-		try {
-			logger.debug("Executing Schema.org query: " + sOrgConstructQuery);
-			Graph resGraph = sAddresses.executeConstructQuery(sOrgConstructQuery);
-			
-			logger.debug("Starting geocoding.");
-			
-			Iterator<Statement> it = resGraph.match(null, RDF.TYPE, postalAddressURI);
-			
-			int cachedToday = countTodaysCacheFiles(ctx);
-			int toCache = (config.getLimit() - cachedToday);
+        Graph graph;
+        try {
+            graph = queryAddresses();
+        } catch (InvalidQueryException e) {
+            logger.error(e.getLocalizedMessage());
+            ctx.sendMessage(MessageType.ERROR, "Failed to query for addresses, ending");
+            return;
+        }
 
-			long lastDownload = 0;
-			while (it.hasNext() && !ctx.canceled() && geocodes <= toCache)
-			{
-				count++;
-				Resource currentAddressURI = it.next().getSubject();
+        Iterator<Statement> it = graph.match(null, RDF.TYPE, sAddresses.createURI("http://schema.org/PostalAddress"));
 
-                Address address = Address.buildFromRdf(config, resGraph, currentAddressURI);
-				logger.debug("Address to geocode (" + count + "/" + total + "): " + address.toString());
-								
-				String file = address.toFilename();
-                if (config.isStructured())
-				{
-					file = "structured-" + file;
-				}
-				//CACHE
-				
-				File hPath = ctx.getGlobalDirectory();
-				File hFile = new File(hPath, file);
-				
-				if (!hFile.exists())
-				{
-					long curTS = date.getTime();
-					if (lastDownload + config.getInterval() > curTS)
-					{
-						logger.debug("Sleeping: " + (lastDownload + config.getInterval() - curTS));
-						try {
-							Thread.sleep(lastDownload + config.getInterval() - curTS);
-						} catch (InterruptedException e) {
-							logger.info("Interrupted while sleeping");
-						}
-					}
+        int allowedRequests = getNumberOfAllowedRequests(ctx);
 
-                    String url = null;
-                    try {
-                        url = address.buildQuery();
-                    } catch (UnsupportedEncodingException e) {
-                        logger.error("Error while building request " + e.getMessage());
-                        e.printStackTrace();
-                    }
+        logger.debug("Starting geocoding, will issue " + allowedRequests + " requests");
 
-                    String out = null;
-					try {
-						out = getURLContent(url.toString());
-					} catch (IOException e1) {
-						logger.error(e1.getLocalizedMessage() +" while geocoding " +  address);
-					}
-					lastDownload = date.getTime();
-					
-					geocodes++;
-					logger.debug("Queried Nominatim (" + geocodes + "): " + address + " as " + url);
-					try {
-						BufferedWriter fw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(hFile), "UTF-8"));
-						fw.append(out);
-						fw.close();
-					} catch (Exception e) {
-						logger.error(e.getLocalizedMessage());
-						e.printStackTrace();
-					}
-					//CACHED
-				}
-				else {
-					cacheHits++;
-					logger.debug("From cache (" + cacheHits + "): " + address);
-				}
-				
-				//READ FROM FILE - NOW IT EXISTS
-				String cachedFile = null;
-				try {
-					cachedFile = FileUtils.readFileToString(hFile);
-				} catch (IOException e) {
-					logger.error(e.getLocalizedMessage());
-				}
+        long lastDownload = 0;
+        while (it.hasNext() && !ctx.canceled() && geocoded <= allowedRequests)
+        {
+            count++;
+            Resource currentAddressURI = it.next().getSubject();
 
-				try {
-					Geo[] gs = gson.fromJson(cachedFile, Geo[].class);
-					if (gs == null || gs.length == 0) {
-						failed++;
-						logger.debug("Failed to geolocate (" + failed + "): " + address);
-						continue;
-					}
-					
-					BigDecimal latitude = new BigDecimal(gs[0].lat);
-					BigDecimal longitude = new BigDecimal(gs[0].lon);
-					
-					logger.debug("Located: " + address + " Possibilities: " + gs.length + " Latitude: " + latitude + " Longitude: " + longitude);
-					
-					String uri = currentAddressURI.stringValue();
-					URI addressURI = outGeo.createURI(uri);
-					URI coordURI = outGeo.createURI(uri+"/geocoordinates/nominatim");
-					
-					outGeo.addTriple(addressURI, geoURI , coordURI);
-					outGeo.addTriple(coordURI, RDF.TYPE, geocoordsURI);
-					outGeo.addTriple(coordURI, longURI, outGeo.createLiteral(longitude.toString()/*, xsdDecimal*/));
-					outGeo.addTriple(coordURI, latURI, outGeo.createLiteral(latitude.toString()/*, xsdDecimal*/));
-					outGeo.addTriple(coordURI, dcsource, nominatimURI);
+            Address address = Address.buildFromRdf(config, graph, currentAddressURI);
 
-                    if (config.isGenerateMapUrl()) {
-                        URI webURI = outGeo.createURI("http://www.openstreetmap.org/search?query=#map=13/" + latitude.toString() + "/" + longitude.toString());
-                        outGeo.addTriple(coordURI, urlURI, webURI);
-                    }
-				} catch (Exception e) {
-					logger.warn(e.getLocalizedMessage());
-					e.printStackTrace();
-				}
-				
-			}
-			if (ctx.canceled()) logger.info("Cancelled");
-			
-		} catch (InvalidQueryException e) {
-			logger.error(e.getLocalizedMessage());
-		}
+            logger.debug("Address to geocode (" + count + "/" + total + "): " + address.toString());
+
+            File hFile = getCacheFile(ctx, address.toFilename());
+
+            if (!hFile.exists())
+            {
+                lastDownload = requestAndCache(date, lastDownload, address, hFile);
+            }
+            else {
+                cacheHits++;
+                logger.debug("From cache (" + cacheHits + "): " + address);
+            }
+
+            try {
+                QueryResult result = readDataFromCache(address, hFile);
+                if (result == null) {
+                    failed++;
+                    logger.debug("Failed to geolocate (" + failed + "): " + address);
+                } else {
+                    logger.debug("Located: " + address + " Possibilities: " + result.getLength() + " Latitude: " + result.getLatitude() + " Longitude: " + result.getLongitude());
+                    appendResultToDataUnit(result, currentAddressURI);
+                }
+            } catch (IOException e) {
+                logger.error(e.getLocalizedMessage());
+                e.printStackTrace();
+            }
+        }
+
+        if (ctx.canceled()) {
+            logger.info("Cancelled");
+        }
 
        	logger.info("Geocoding done.");
 
 		java.util.Date date2 = new java.util.Date();
 		long end = date2.getTime();
 
-		ctx.sendMessage(MessageType.INFO, "Geocoded " + count + ": Nominatim: "+ geocodes +" From cache: " + cacheHits + " in " + (end-start) + "ms, failed attempts: " + failed);
-
+		ctx.sendMessage(MessageType.INFO, "Geocoded " + count + ": Nominatim: "+ geocoded +" From cache: " + cacheHits + " in " + (end-start) + "ms, failed attempts: " + failed);
 	}
+
+    private void appendResultToDataUnit(QueryResult result, Resource currentAddressURI) {
+        URI dcsource = outGeo.createURI("http://purl.org/dc/terms/source");
+        URI nominatimURI = outGeo.createURI("http://nominatim.openstreetmap.org");
+        URI geoURI = outGeo.createURI("http://schema.org/geo");
+        URI geocoordsURI = outGeo.createURI("http://schema.org/GeoCoordinates");
+        URI longURI = outGeo.createURI("http://schema.org/longitude");
+        URI latURI = outGeo.createURI("http://schema.org/latitude");
+        URI urlURI = outGeo.createURI("http://schema.org/url");
+
+        String uri = currentAddressURI.stringValue();
+        URI addressURI = outGeo.createURI(uri);
+        URI coordURI = outGeo.createURI(uri+"/geocoordinates/nominatim");
+
+        outGeo.addTriple(addressURI, geoURI , coordURI);
+        outGeo.addTriple(coordURI, RDF.TYPE, geocoordsURI);
+        outGeo.addTriple(coordURI, latURI, outGeo.createLiteral(result.getLatitude().toString()));
+        outGeo.addTriple(coordURI, longURI, outGeo.createLiteral(result.getLongitude().toString()));
+        outGeo.addTriple(coordURI, dcsource, nominatimURI);
+
+        if (config.isGenerateMapUrl()) {
+            URI webURI = outGeo.createURI("http://www.openstreetmap.org/search?query=#map=13/" + result.getLatitude().toString() + "/" + result.getLongitude().toString());
+            outGeo.addTriple(coordURI, urlURI, webURI);
+        }
+    }
+
+    private QueryResult readDataFromCache(Address address, File hFile) throws IOException {
+        Gson gson = new GsonBuilder().registerTypeAdapter(Geo.class, new GeoInstanceCreator()).create();
+        String cachedFile = FileUtils.readFileToString(hFile);
+
+        Geo[] gs = gson.fromJson(cachedFile, Geo[].class);
+        if (gs == null || gs.length == 0) {
+            return null;
+        } else {
+            return new QueryResult(new BigDecimal(gs[0].lat), new BigDecimal(gs[0].lon), gs.length);
+        }
+    }
+
+    private File getCacheFile(DPUContext ctx, String file) {
+        File hPath = ctx.getGlobalDirectory();
+        return new File(hPath, file);
+    }
+
+    private long requestAndCache(Date date, long lastDownload, Address address, File hFile) {
+        long curTS = date.getTime();
+        if (lastDownload + config.getInterval() > curTS)
+        {
+            logger.debug("Sleeping: " + (lastDownload + config.getInterval() - curTS));
+            try {
+                Thread.sleep(lastDownload + config.getInterval() - curTS);
+            } catch (InterruptedException e) {
+                logger.info("Interrupted while sleeping");
+            }
+        }
+
+        String url = null;
+        try {
+            url = address.buildQuery();
+        } catch (UnsupportedEncodingException e) {
+            logger.error("Error while building request " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        String out = null;
+        try {
+            out = getURLContent(url.toString());
+        } catch (IOException e1) {
+            logger.error(e1.getLocalizedMessage() +" while geocoding " +  address);
+        }
+        lastDownload = date.getTime();
+
+        geocoded++;
+        logger.debug("Queried Nominatim (" + geocoded + "): " + address + " as " + url);
+        try {
+            BufferedWriter fw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(hFile), "UTF-8"));
+            fw.append(out);
+            fw.close();
+        } catch (Exception e) {
+            logger.error(e.getLocalizedMessage());
+            e.printStackTrace();
+        }
+        //CACHED
+        return lastDownload;
+    }
+
+    private static String getURLContent(String p_sURL) throws IOException
+    {
+        URL oURL;
+        String sResponse = null;
+
+        oURL = new URL(p_sURL);
+        try	{
+            sResponse = IOUtils.toString(oURL, "UTF-8");
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+        return sResponse;
+    }
+
+    private int countAddressesInSourceDataUnit() {
+        String query = "PREFIX s: <http://schema.org/> "
+                + "SELECT (COUNT (*) as ?count) "
+                + "WHERE "
+                + "{"
+                    + "?address a s:PostalAddress . "
+                +  "}";
+
+        int total = 0;
+        try {
+            MyTupleQueryResultIf countres = sAddresses.executeSelectQueryAsTuples(query);
+            total = Integer.parseInt(countres.next().getValue("count").stringValue());
+        } catch (InvalidQueryException e1) {
+            logger.error(e1.getLocalizedMessage());
+        } catch (NumberFormatException e) {
+            logger.error(e.getLocalizedMessage());
+        } catch (QueryEvaluationException e) {
+            logger.error(e.getLocalizedMessage());
+        }
+        return total;
+    }
+
+    private Graph queryAddresses() throws InvalidQueryException {
+        String sOrgConstructQuery = "PREFIX s: <http://schema.org/> "
+                + "CONSTRUCT {?address ?p ?o}"
+                + "WHERE "
+                + "{"
+                + "?address a s:PostalAddress ;"
+                + "			?p ?o . "
+                +  "}";
+
+        logger.debug("Executing Schema.org query: " + sOrgConstructQuery);
+        return sAddresses.executeConstructQuery(sOrgConstructQuery);
+    }
+
+    private int getNumberOfAllowedRequests(DPUContext ctx) {
+        int cached = countCachedRequestsInPeriod(ctx);
+        return (config.getLimit() - cached);
+    }
+
+    private int countCachedRequestsInPeriod(DPUContext ctx)
+    {
+        int count = 0;
+
+        // Directory path here
+        File currentFile;
+        File folder = ctx.getGlobalDirectory();
+        if (!folder.isDirectory()) return 0;
+
+        File[] listOfFiles = folder.listFiles();
+        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
+
+        for (int i = 0; i < listOfFiles.length; i++)
+        {
+            if (listOfFiles[i].isFile())
+            {
+                currentFile = listOfFiles[i];
+
+                Date now = new Date();
+                Date modified = null;
+                try {
+                    modified = sdf.parse(sdf.format(currentFile.lastModified()));
+                } catch (ParseException e) {
+                    logger.error(e.getLocalizedMessage());
+                }
+                long diff = (now.getTime() - modified.getTime()) / 1000;
+
+                if (diff < (config.getLimitPeriod() * 60 * 60)) count++;
+            }
+        }
+        logger.info("Total of " + count + " positions cached in last " + config.getLimitPeriod() + " hours.");
+        return count;
+    }
 
     @Override
 	public void cleanUp() {	}
+
+
+
+    public class Response {
+        public Map<String, Geo> descriptor;
+        //getters&setters
+        public Response () {  }
+    }
+
+    public class Geo {
+        public String lat;
+        public String lon;
+        //getters&setters
+        public Geo () {  }
+    }
+
+    public class GeoInstanceCreator implements InstanceCreator<Geo> {
+        public Geo createInstance(Type type) {
+            return new Geo();
+        }
+    }
 
 }

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
@@ -279,11 +279,15 @@ implements ConfigDialogProvider<ExtractorConfig> {
 
     private Graph queryAddresses() throws InvalidQueryException {
         String sOrgConstructQuery = "PREFIX s: <http://schema.org/> "
-                + "CONSTRUCT {?address ?p ?o}"
+                + "CONSTRUCT {?address ?p ?o ; s:addressCountry ?country}"
                 + "WHERE "
                 + "{"
                 + "?address a s:PostalAddress ;"
                 + "			?p ?o . "
+                + " OPTIONAL {"
+                        + "?address s:addressCountry ?c ."
+                        + "?c s:name ?country ."
+                + "}"
                 +  "}";
 
         logger.debug("Executing Schema.org query: " + sOrgConstructQuery);

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
@@ -110,10 +110,10 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 				long diff = (now.getTime() - modified.getTime()) / 1000;
 				//System.out.println("Date modified: " + sdf.format(currentFile.lastModified()) + " which is " + diff + " seconds ago.");
 
-				if (diff < (config.getHoursToCheck() * 60 * 60)) count++;
+				if (diff < (config.getLimitPeriod() * 60 * 60)) count++;
 			}
 		}
-		logger.info("Total of " + count + " positions cached in last " + config.getHoursToCheck() + " hours. " + (config.getLimit() - count) + " remaining.");
+		logger.info("Total of " + count + " positions cached in last " + config.getLimitPeriod() + " hours. " + (config.getLimit() - count) + " remaining.");
 		return count;
 	}
 	
@@ -309,7 +309,7 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 				} catch (IOException e) {
 					logger.error(e.getLocalizedMessage());
 				}
-				
+
 				try {
 					Geo[] gs = gson.fromJson(cachedFile, Geo[].class);
 					if (gs == null || gs.length == 0) {

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/Extractor.java
@@ -326,14 +326,17 @@ implements DPU, ConfigDialogProvider<ExtractorConfig> {
 					String uri = currentAddressURI.stringValue();
 					URI addressURI = outGeo.createURI(uri);
 					URI coordURI = outGeo.createURI(uri+"/geocoordinates/nominatim");
-                    URI webURI = outGeo.createURI("http://www.openstreetmap.org/search?query=#map=13/" + latitude.toString() + "/" + longitude.toString());
 					
 					outGeo.addTriple(addressURI, geoURI , coordURI);
 					outGeo.addTriple(coordURI, RDF.TYPE, geocoordsURI);
 					outGeo.addTriple(coordURI, longURI, outGeo.createLiteral(longitude.toString()/*, xsdDecimal*/));
 					outGeo.addTriple(coordURI, latURI, outGeo.createLiteral(latitude.toString()/*, xsdDecimal*/));
 					outGeo.addTriple(coordURI, dcsource, nominatimURI);
-                    outGeo.addTriple(coordURI, urlURI, webURI);
+
+                    if (config.isGenerateMapUrl()) {
+                        URI webURI = outGeo.createURI("http://www.openstreetmap.org/search?query=#map=13/" + latitude.toString() + "/" + longitude.toString());
+                        outGeo.addTriple(coordURI, urlURI, webURI);
+                    }
 				} catch (Exception e) {
 					logger.warn(e.getLocalizedMessage());
 					e.printStackTrace();

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorConfig.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorConfig.java
@@ -30,8 +30,9 @@ public class ExtractorConfig extends DPUConfigObjectBase {
     private boolean useLocality = true;
     
     private boolean usePostalCode = false;
+    private boolean useCountry;
 
-	public int getLimit() {
+    public int getLimit() {
 		return limit;
 	}
 
@@ -117,5 +118,13 @@ public class ExtractorConfig extends DPUConfigObjectBase {
 
     public void setGenerateMapUrl(boolean generateMapUrl) {
         this.generateMapUrl = generateMapUrl;
+    }
+
+    public boolean isUseCountry() {
+        return useCountry;
+    }
+
+    public void setUseCountry(boolean useCountry) {
+        this.useCountry = useCountry;
     }
 }

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorConfig.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorConfig.java
@@ -9,8 +9,6 @@ import cz.cuni.mff.xrg.odcs.commons.module.config.DPUConfigObjectBase;
  */
 public class ExtractorConfig extends DPUConfigObjectBase {
 	
-	private static final long serialVersionUID = 8719241993054209502L;
-
 	private int limit = 2400;
 	
 	private int interval = 1000;

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorConfig.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorConfig.java
@@ -13,9 +13,9 @@ public class ExtractorConfig extends DPUConfigObjectBase {
 	
 	private int interval = 1000;
 	
-    private int hoursToCheck = 24;
+    private int limitPeriod = 24;
     
-    private boolean structured = false;
+    private boolean isStructured = false;
 	
     private boolean stripNumFromLocality = true;
     
@@ -45,20 +45,20 @@ public class ExtractorConfig extends DPUConfigObjectBase {
 		this.interval = interval;
 	}
 
-	public int getHoursToCheck() {
-		return hoursToCheck;
+	public int getLimitPeriod() {
+		return limitPeriod;
 	}
 
-	public void setHoursToCheck(int hoursToCheck) {
-		this.hoursToCheck = hoursToCheck;
+	public void setLimitPeriod(int limitPeriod) {
+		this.limitPeriod = limitPeriod;
 	}
 
 	public boolean isStructured() {
-		return structured;
+		return isStructured;
 	}
 
 	public void setStructured(boolean structured) {
-		this.structured = structured;
+		this.isStructured = structured;
 	}
 
 	public boolean isStripNumFromLocality() {

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorConfig.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorConfig.java
@@ -18,6 +18,8 @@ public class ExtractorConfig extends DPUConfigObjectBase {
     private boolean isStructured = false;
 	
     private boolean stripNumFromLocality = true;
+
+    private boolean generateMapUrl = false;
     
     private String country = "";
     
@@ -108,5 +110,12 @@ public class ExtractorConfig extends DPUConfigObjectBase {
 	public void setUsePostalCode(boolean usePostalCode) {
 		this.usePostalCode = usePostalCode;
 	}
-    
+
+    public boolean isGenerateMapUrl() {
+        return generateMapUrl;
+    }
+
+    public void setGenerateMapUrl(boolean generateMapUrl) {
+        this.generateMapUrl = generateMapUrl;
+    }
 }

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorDialog.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorDialog.java
@@ -20,6 +20,7 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
     private TextField country;
     private CheckBox isStructured;
     private CheckBox stripNumFromLocality;
+    private CheckBox generateMapUrl;
     private TwinColSelect tcsProperties;
     private String properties[] = {"s:streetAddress", "s:addressRegion", "s:addressLocality", "s:postalCode"};
     
@@ -45,17 +46,20 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
         setWidth("100%");
         setHeight("100%");
 
-        isStructured = new CheckBox("Structured query (experimental):");
+        isStructured = new CheckBox("Structured query (experimental)");
         isStructured.setDescription("When selected, Nominatim will be queried by structured queries.");
         isStructured.setWidth("100%");
-        
         mainLayout.addComponent(isStructured);
 
-        stripNumFromLocality = new CheckBox("Strip number form Locality:");
+        stripNumFromLocality = new CheckBox("Strip number form Locality");
         stripNumFromLocality.setDescription("In structured query, replace Praha 6 => Praha, etc.");
         stripNumFromLocality.setWidth("100%");
-        
         mainLayout.addComponent(stripNumFromLocality);
+
+        generateMapUrl = new CheckBox("Generate schema:url property with direct link to map");
+        generateMapUrl.setDescription("Useful option for debugging results, URL to the service is constructed automatically and can be opened from SPARQL query result");
+        generateMapUrl.setWidth("100%");
+        mainLayout.addComponent(generateMapUrl);
 
         country = new TextField();
         country.setCaption("Country");
@@ -93,6 +97,7 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 		limit.setValue(Integer.toString(conf.getLimit()));
 		country.setValue(conf.getCountry());
 		isStructured.setValue(conf.isStructured());
+		generateMapUrl.setValue(conf.isGenerateMapUrl());
 		stripNumFromLocality.setValue(conf.isStripNumFromLocality());
 
 		LinkedList<String> values = new LinkedList<String>();
@@ -112,7 +117,8 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 		conf.setLimit(Integer.parseInt(limit.getValue()));
 		conf.setStructured(isStructured.getValue());
 		conf.setStripNumFromLocality(stripNumFromLocality.getValue());
-		
+		conf.setGenerateMapUrl(generateMapUrl.getValue());
+
 		Collection<String> values = (Collection<String>)tcsProperties.getValue();
 		conf.setUseStreet(values.contains(properties[0])); 
 		conf.setUseRegion(values.contains(properties[1]));

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorDialog.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorDialog.java
@@ -22,7 +22,7 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
     private CheckBox stripNumFromLocality;
     private CheckBox generateMapUrl;
     private TwinColSelect tcsProperties;
-    private String properties[] = {"s:streetAddress", "s:addressRegion", "s:addressLocality", "s:postalCode"};
+    private String properties[] = {"s:streetAddress", "s:addressRegion", "s:addressLocality", "s:postalCode", "s:addressCountry"};
     
 	public ExtractorDialog() {
 		super(ExtractorConfig.class);
@@ -63,6 +63,7 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 
         country = new TextField();
         country.setCaption("Country");
+        country.setDescription("Fallback to schema:addressCountry property");
         mainLayout.addComponent(country);
 
         interval = new TextField();
@@ -105,6 +106,7 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 		if (conf.isUseRegion()) values.add(properties[1]);
 		if (conf.isUseLocality()) values.add(properties[2]);
 		if (conf.isUsePostalCode()) values.add(properties[3]);
+		if (conf.isUseCountry()) values.add(properties[4]);
 		tcsProperties.setValue(values);
 	}
 
@@ -124,7 +126,8 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 		conf.setUseRegion(values.contains(properties[1]));
 		conf.setUseLocality(values.contains(properties[2]));
 		conf.setUsePostalCode(values.contains(properties[3]));
-		
+		conf.setUseCountry(values.contains(properties[4]));
+
 		return conf;
 	}
 	

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorDialog.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorDialog.java
@@ -1,12 +1,11 @@
 package cz.opendata.linked.geocoder.nominatim;
 
 import com.vaadin.ui.*;
-import java.util.Collection;
-import java.util.LinkedList;
-
-
 import cz.cuni.mff.xrg.odcs.commons.configuration.ConfigException;
 import cz.cuni.mff.xrg.odcs.commons.module.dialog.BaseConfigDialog;
+
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * DPU's configuration dialog. User can use this dialog to configure DPU configuration.
@@ -17,10 +16,10 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 	private GridLayout mainLayout;
     private TextField interval;
     private TextField limit;
-    private TextField hoursToCheck;
-    private TextField tfCountry;
-    private CheckBox chkStructured;
-    private CheckBox chkStripNumFromLocality;
+    private TextField limitPeriod;
+    private TextField country;
+    private CheckBox isStructured;
+    private CheckBox stripNumFromLocality;
     private TwinColSelect tcsProperties;
     private String properties[] = {"s:streetAddress", "s:addressRegion", "s:addressLocality", "s:postalCode"};
     
@@ -46,33 +45,33 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
         setWidth("100%");
         setHeight("100%");
 
-        chkStructured = new CheckBox("Structured query (experimental):");
-        chkStructured.setDescription("When selected, Nominatim will be queried by structured queries.");
-        chkStructured.setWidth("100%");
+        isStructured = new CheckBox("Structured query (experimental):");
+        isStructured.setDescription("When selected, Nominatim will be queried by structured queries.");
+        isStructured.setWidth("100%");
         
-        mainLayout.addComponent(chkStructured);
+        mainLayout.addComponent(isStructured);
 
-        chkStripNumFromLocality = new CheckBox("Strip number form Locality:");
-        chkStripNumFromLocality.setDescription("In structured query, replace Praha 6 => Praha, etc.");
-        chkStripNumFromLocality.setWidth("100%");
+        stripNumFromLocality = new CheckBox("Strip number form Locality:");
+        stripNumFromLocality.setDescription("In structured query, replace Praha 6 => Praha, etc.");
+        stripNumFromLocality.setWidth("100%");
         
-        mainLayout.addComponent(chkStripNumFromLocality);
+        mainLayout.addComponent(stripNumFromLocality);
 
-        tfCountry = new TextField();
-        tfCountry.setCaption("Country");
-        mainLayout.addComponent(tfCountry);
+        country = new TextField();
+        country.setCaption("Country");
+        mainLayout.addComponent(country);
 
         interval = new TextField();
-        interval.setCaption("Interval between downloads:");
+        interval.setCaption("Interval between downloads (sec):");
         mainLayout.addComponent(interval);
 
         limit = new TextField();
-        limit.setCaption("Maximum amount of downloads:");
+        limit.setCaption("Maximum number of downloads:");
         mainLayout.addComponent(limit);
 
-        hoursToCheck = new TextField();
-        hoursToCheck.setCaption("Maximum amount interval:");
-        mainLayout.addComponent(hoursToCheck);
+        limitPeriod = new TextField();
+        limitPeriod.setCaption("Length of period for which the limit is applied (hrs):");
+        mainLayout.addComponent(limitPeriod);
 
         tcsProperties = new TwinColSelect("Select properties to use");
 		tcsProperties.setSizeFull();
@@ -90,11 +89,11 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 	@Override
 	public void setConfiguration(ExtractorConfig conf) throws ConfigException {
 		interval.setValue(Integer.toString(conf.getInterval()));
-		hoursToCheck.setValue(Integer.toString(conf.getHoursToCheck()));
+		limitPeriod.setValue(Integer.toString(conf.getLimitPeriod()));
 		limit.setValue(Integer.toString(conf.getLimit()));
-		tfCountry.setValue(conf.getCountry());
-		chkStructured.setValue(conf.isStructured());
-		chkStripNumFromLocality.setValue(conf.isStripNumFromLocality());
+		country.setValue(conf.getCountry());
+		isStructured.setValue(conf.isStructured());
+		stripNumFromLocality.setValue(conf.isStripNumFromLocality());
 
 		LinkedList<String> values = new LinkedList<String>();
 		if (conf.isUseStreet()) values.add(properties[0]);
@@ -108,11 +107,11 @@ public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 	public ExtractorConfig getConfiguration() throws ConfigException {
 		ExtractorConfig conf = new ExtractorConfig();
 		conf.setInterval(Integer.parseInt(interval.getValue()));
-		conf.setHoursToCheck(Integer.parseInt(hoursToCheck.getValue()));
-		conf.setCountry(tfCountry.getValue());
+		conf.setLimitPeriod(Integer.parseInt(limitPeriod.getValue()));
+		conf.setCountry(country.getValue());
 		conf.setLimit(Integer.parseInt(limit.getValue()));
-		conf.setStructured((boolean) chkStructured.getValue());
-		conf.setStripNumFromLocality((boolean) chkStripNumFromLocality.getValue());
+		conf.setStructured(isStructured.getValue());
+		conf.setStripNumFromLocality(stripNumFromLocality.getValue());
 		
 		Collection<String> values = (Collection<String>)tcsProperties.getValue();
 		conf.setUseStreet(values.contains(properties[0])); 

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorDialog.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/ExtractorDialog.java
@@ -14,8 +14,6 @@ import cz.cuni.mff.xrg.odcs.commons.module.dialog.BaseConfigDialog;
  */
 public class ExtractorDialog extends BaseConfigDialog<ExtractorConfig> {
 	
-	private static final long serialVersionUID = 7003725620084616056L;
-	
 	private GridLayout mainLayout;
     private TextField interval;
     private TextField limit;

--- a/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/QueryResult.java
+++ b/nominatim/src/main/java/cz/opendata/linked/geocoder/nominatim/QueryResult.java
@@ -1,0 +1,29 @@
+package cz.opendata.linked.geocoder.nominatim;
+
+import java.math.BigDecimal;
+
+public class QueryResult {
+
+    private int length = 0;
+    private BigDecimal latitude = new BigDecimal(0);
+    private BigDecimal longitude = new BigDecimal(0);
+
+    public QueryResult(BigDecimal lat, BigDecimal lon, int length) {
+        this.latitude = lat;
+        this.longitude = lon;
+        this.length = length;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+}


### PR DESCRIPTION
I've modified Google Geocoder and Nominatim Geocoder DPUs. I added a checkbox style option to add schema:url with direct link to respective map services for debugging purposes and extended SPARQL query to extract country of the address from schema:addressCountry or schema:addressCountry/schema:name.

As for Google specific changes, handling of zero response case is handled correctly and is logged.

Changes for Nominatim are larger. I refactored the code, extracted class Address for generating different representations (structured/unstructured query, cache filename, human-readable version), slightly enhanced option for stripping numbers from schema:addressLocality to include Roman numerals as well. Based on tests I added automatic fallback option for cases when geocoding fails and the schema:streetAddress consist either only of digits (17, Stárkov, CZ) or contains value of schema:addressLocality (Stárkov 17, Stárkov, CZ). Second request is issued with schema:streetAddress replaced by schema:addressLocality (Stárkov, Stárkov, CZ). This happens often for small cities/villages where streets don't have names and Nominatim gets confused. Querying with the fallback format yields reasonable results in most cases.
