### PR TITLE
XSLT DPU, Extractor unzipper updates

### DIFF
--- a/XSLT/src/main/java/cz/cuni/mff/xrg/intlib/extractor/simplexslt/SimpleXSLT.java
+++ b/XSLT/src/main/java/cz/cuni/mff/xrg/intlib/extractor/simplexslt/SimpleXSLT.java
@@ -45,6 +45,9 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+
+
+import cz.opendata.linked.saxon.extensions.UUIDGenerator;
 import org.openrdf.model.Resource;
 import org.openrdf.model.URI;
 import org.openrdf.model.Value;
@@ -53,6 +56,9 @@ import org.openrdf.query.BindingSet;
 import org.openrdf.query.QueryEvaluationException;
 import org.openrdf.query.TupleQueryResult;
 import org.slf4j.LoggerFactory;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.TransformerFactoryImpl;
 
 /**
  * Simple XSLT Extractor
@@ -188,6 +194,12 @@ public class SimpleXSLT extends ConfigurableBase<SimpleXSLTConfig> implements Co
 
         //try to compile XSLT
         TransformerFactory tfactory = new net.sf.saxon.TransformerFactoryImpl(); //TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null);
+
+	    // register extension function
+	    TransformerFactoryImpl tFactoryImpl = (TransformerFactoryImpl) tfactory;
+	    Configuration saxonConfig = tFactoryImpl.getConfiguration();
+	    saxonConfig.registerExtensionFunction(new UUIDGenerator());
+
         Templates templates;
         try {
             templates = tfactory.newTemplates(new StreamSource(xslTemplate));

--- a/XSLT/src/main/java/cz/cuni/mff/xrg/intlib/extractor/simplexslt/SimpleXSLTConfig.java
+++ b/XSLT/src/main/java/cz/cuni/mff/xrg/intlib/extractor/simplexslt/SimpleXSLTConfig.java
@@ -59,6 +59,7 @@ public class SimpleXSLTConfig extends DPUConfigObjectBase {
 	public void setOutputXSLTMethod(String outputXSLTMethod) {
 		this.outputXSLTMethod = outputXSLTMethod;
 	}
+
     
 //    //not used, but needed for backward compatibility
 //    private String storedXsltFilePath = "";
@@ -75,11 +76,19 @@ public class SimpleXSLTConfig extends DPUConfigObjectBase {
     
     //INPUT PREDICATE IN RDF DATA UNIT HOLDING URI which should be used as a subject for the given file 
     //when OutputType.Literal is used
-    public static final String DATA_UNIT_RESULTING_SUBJECT_PREDICATE = "http://linked.opendata.cz/ontology/odcs/resultingSubject";
+    public static String DATA_UNIT_RESULTING_SUBJECT_PREDICATE = "http://linked.opendata.cz/ontology/odcs/resultingSubject";
     //predicate holding path to the file data unit. 
     //Object is used to map subject with the particular file in file data unit. 
     //Subject is an arbitrary URI, which may be used to define other properties of the file in the file data unit. 
-    public static final String FILE_DATAUNIT_PATH = "http://linked.opendata.cz/ontology/odcs/dataunit/file/filePath";
+    public static String FILE_DATAUNIT_PATH = "http://linked.opendata.cz/ontology/odcs/dataunit/file/filePath";
+
+	public void setDATA_UNIT_RESULTING_SUBJECT_PREDICATE(String s) {
+		DATA_UNIT_RESULTING_SUBJECT_PREDICATE = s;
+	}
+
+	public void setFILE_DATAUNIT_PATH(String s) {
+		FILE_DATAUNIT_PATH = s;
+	}
 
     public String getResultingSubjectPredicate() {
         return DATA_UNIT_RESULTING_SUBJECT_PREDICATE;

--- a/XSLT/src/main/java/cz/opendata/linked/saxon/extensions/UUIDGenerator.java
+++ b/XSLT/src/main/java/cz/opendata/linked/saxon/extensions/UUIDGenerator.java
@@ -1,0 +1,51 @@
+package cz.opendata.linked.saxon.extensions;
+
+
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.lib.ExtensionFunctionCall;
+import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.Item;
+import net.sf.saxon.om.SequenceIterator;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.trans.XPathException;
+import net.sf.saxon.tree.iter.SingletonIterator;
+import net.sf.saxon.value.SequenceType;
+import net.sf.saxon.value.StringValue;
+
+
+public class UUIDGenerator extends ExtensionFunctionDefinition {
+
+
+	@Override
+	public StructuredQName getFunctionQName() {
+		return new StructuredQName("uuid","http://linked.opendata.cz/xslt-functions", "randomUUID");
+	}
+
+	@Override
+	public SequenceType[] getArgumentTypes() {
+		return new SequenceType[0];
+	}
+
+	@Override
+	public SequenceType getResultType(SequenceType[] sequenceTypes) {
+		return SequenceType.SINGLE_STRING;
+	}
+
+	@Override
+	public ExtensionFunctionCall makeCallExpression() {
+		return new ExtensionFunctionCall() {
+
+			@Override
+			public SequenceIterator call(SequenceIterator[] sequenceIterators, XPathContext xPathContext) throws XPathException {
+
+				Item item = new StringValue(java.util.UUID.randomUUID().toString());
+
+				return SingletonIterator.makeIterator(item);
+			}
+
+		};
+	}
+
+
+
+}

--- a/extractor_unzipper/pom.xml
+++ b/extractor_unzipper/pom.xml
@@ -10,13 +10,13 @@
     
 	<artifactId>extractor_unzipper</artifactId>
     
-	<version>1.0.0</version>
+	<version>1.0.1</version>
     
 	<packaging>bundle</packaging>
     
 	<description>
-    This extractor downloads a ZIP archive and extracts files from it to an output data file unit.
-  </description>
+    This extractor downloads a zip or tar.gz archive and extracts files from it to an output data file unit.
+    </description>
     
 	<properties>
 		<dpu.package>cz.opendata.linked.extractor.unzipper</dpu.package>
@@ -25,10 +25,16 @@
  	
 	<dependencies>
 		<dependency>
-			<groupId>net.lingala.zip4j</groupId>
-			<artifactId>zip4j</artifactId>
-			<version>1.2.3</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.8</version>
 		</dependency>
+		<dependency>
+			<groupId>org.tukaani</groupId>
+			<artifactId>xz</artifactId>
+			<version>1.0</version>
+		</dependency>
+
 	</dependencies>
  	
 </project>


### PR DESCRIPTION
Added saxon extension about java UUID generation for XSLT DPU. Name of function is randomUUID and is located in namespace http://linked.opendata.cz/xslt-functions.
Added tar.gz support to Extractor_unzipper.
